### PR TITLE
Patch to bring HTMLToCleanTxt.pl more in line with modern Perl best practices

### DIFF
--- a/HTMLToCleanTxt.pl
+++ b/HTMLToCleanTxt.pl
@@ -1,29 +1,31 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use autodie 2.12 qw(:file);
+
 use HTML::Restrict;
-#available from http://search.cpan.org/~oalders/HTML-Restrict-2.2.2/lib/HTML/Restrict.pm
+# Available from https://api.metacpan.org/source/OALDERS/HTML-Restrict-2.2.2/lib/HTML/Restrict.pm
 
-#Open and stringify a specific HTML file
-  local $/ = undef;
-  open $file, "AliceInWonderland.html" || die "Couldn't open file: $!";
-  binmode $file;
-  $string = <$file>;
-  close $file;
+use open IO => ':raw';
 
+# Open and stringify a specific HTML file
+open(my $file, '<', 'AliceInWonderland.html');
+my $string = do {
+	local $/;
+	<$file>;
+};
+close $file;
 
-#Process the stringified file to remove HTML tags
+# Process the stringified file to remove HTML tags
 my $hr = HTML::Restrict->new();
 my $processed = $hr->process($string);
 
-#Set up new txt file
-my $newfile = "AliceInWonderland.txt";
-
-#Use the open() function to create the file
-unless(open FILE, '>'.$newfile) {
-     Die with error message 
-    # if we can't open it.
-    die "\nUnable to create $file\n";
-}
+# Use the open() function to create the new txt file
+open(my $output, '>', 'AliceInWonderland.txt');
 
 # Write the cleaned raw text from the HTML file to the new file
-print FILE $processed;
-#Close the file
-close FILE;
+print $output $processed;
+
+# Close the new file
+close $output;


### PR DESCRIPTION
Thanks for a really useful little script! Some of the Perl idioms it uses are a bit antiquated though, and even deprecated in some cases; I've updated it slightly to better reflect 'modern' Perl:
- Added shebang line and changed file permissions to 755 to make script executable;
- Always `use strict;` and `use warnings;`
- All variables now declared with `my`;
- `use autodie;` (from 2.12 onwards) means never having to say `or die` when opening files;
- Updated link to HTML::Restrict to MetaCPAN;
- `use open` with `:raw` mode lets us skip calling `binmode()` for open files after the fact;
- Use the three-argument form of `open()` for safety;
- Input record separator shenanigans now restricted to a single block;
- Removed unnecessary `$newfile` variable;
- Replaced bareword filehandles with lexical file handles;

If you're interested I've also created [another patch](https://github.com/carwash/TextCleanup/tree/args) that lets you process several files at once, specify which files you'd like to work on from the command line, rather than having to edit the source code every time. If you accept this pull request, I can send another for that one, if you like.

Hope this is useful. Best wishes, and thanks again!
Marcus
