### PR TITLE
Patch adding the ability to specify a list of files to process as command line arguments.

### DIFF
--- a/HTMLToCleanTxt.pl
+++ b/HTMLToCleanTxt.pl
@@ -2,30 +2,60 @@
 
 use strict;
 use warnings;
+use 5.014; # Some modern features such as say() and the /r flag on s/// are used.
 use autodie 2.12 qw(:file);
 
+use Fcntl 'O_RDONLY';
+use Tie::File;
+# Available from https://api.metacpan.org/source/TODDR/Tie-File-1.00/lib/Tie/File.pm
 use HTML::Restrict;
 # Available from https://api.metacpan.org/source/OALDERS/HTML-Restrict-2.2.2/lib/HTML/Restrict.pm
 
 use open IO => ':raw';
 
-# Open and stringify a specific HTML file
-open(my $file, '<', 'AliceInWonderland.html');
-my $string = do {
-	local $/;
-	<$file>;
-};
-close $file;
+# Get a list of files to process from the command line
+my @files;
+if (@ARGV) {
+	# If there is only one argument, and it's a text file, use it as the list of files to be processed instead
+	if (@ARGV == 1 && $ARGV[0] =~ /\.txt$/) {
+		tie @files, 'Tie::File', $ARGV[0], mode => O_RDONLY or die "Could not read from file '$ARGV[0]'\n";
+	}
+	else {
+		@files = @ARGV;
+	}
+}
+# If no files specified, default to 'AliceInWonderland.html'
+else {
+	@files = (qw[AliceInWonderland.html]);
+}
 
-# Process the stringified file to remove HTML tags
+# Create a new HTML::Restrict object to process the data
 my $hr = HTML::Restrict->new();
-my $processed = $hr->process($string);
 
-# Use the open() function to create the new txt file
-open(my $output, '>', 'AliceInWonderland.txt');
+# Process each file in turn
+for my $file (@files) {
+	# Open and stringify a specific HTML file
+	open(my $fh, '<', $file);
+	my $string = do {
+		local $/;
+		<$fh>;
+	};
+	close $fh;
 
-# Write the cleaned raw text from the HTML file to the new file
-print $output $processed;
+	# Process the stringified file to remove HTML tags
+	my $processed = $hr->process($string);
 
-# Close the new file
-close $output;
+	# Name the output file according to the input file
+	my $outfile = $file =~ s/(.*)\..{3,4}$/$1.txt/r;
+
+	# Use the open() function to create the new txt file
+	open(my $output, '>', $outfile);
+
+	# Write the cleaned raw text from the HTML file to the new file
+	print $output $processed;
+
+	# Close the new file
+	close $output;
+}
+
+say join('', 'Finished processing ', scalar @files, ' file', (@files == 1 ? '' : 's'), '.');

--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,23 @@ TextCleanup is developed to clean HTML from a .html file and output raw text wit
 Sample file of AliceInWonderland.html included.
 (Entire text of Alice’s Adventures in Wonderland via http://www.gutenberg.org/files/11/11-h/11-h.htm) 
 
-Put this script in the same directory of the file you would like to scrub and run the command 
+To execute, run the command
 
-perl HTMLToCleanTxt.pl
+`perl HTMLToCleanTxt.pl`
 
 in Terminal to create raw text files to work with.
+
+You can name the files you want to process as arguments:
+
+`HTMLToCleanTxt.pl MyFile01.html MyFile02.html`
+
+…or a glob of all HTML files in the directory:
+
+`HTMLToCleanTxt.pl *.html`
+
+If only a single argument is given, and it's a text file, it's assumed to contain a list of files to be processed:
+
+`HTMLToCleanTxt.pl FilesToProcess.txt`
 
 Full instructions for working with this script in Perl: http://ow.ly/Vf09E
 


### PR DESCRIPTION
E.g. `HTMLToCleanTxt.pl MyFile01.html MyFile02.html`

Or a glob: E.g. `HTMLToCleanTxt.pl *.html`

If only a single argument is given, and it's a text file, it's assumed to contain a list of files to be processed: `HTMLToCleanTxt.pl FilesToProcess.txt`

**Nb that with this patch the script will require another non-core module (Tie::File) as well as Perl version 5.14 or greater.**

Best wishes,
Marcus
